### PR TITLE
knative-1.18 release added to eventing, kafka-broker and kn-plugin

### DIFF
--- a/adjust/eventing-kafka-broker/release-1.18/adjust.sh
+++ b/adjust/eventing-kafka-broker/release-1.18/adjust.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#Export USER before test starts
+sed -i "/^source.*/a export USER=$\(whoami\)" test/e2e-tests.sh
+#Increase e2e timeout to 60m
+sed -i "s/\(go_test_e2e.*\)timeout=20m\(.*\).*/\1timeout=40m\2/g" test/e2e-tests.sh
+# ppc64le.patch is already copied to tmp during setup-environment.sh run
+git apply /tmp/ppc64le.patch
+echo "Source code patched successfully"

--- a/adjust/eventing-kafka-broker/release-1.18/ppc64le.patch
+++ b/adjust/eventing-kafka-broker/release-1.18/ppc64le.patch
@@ -1,0 +1,83 @@
+diff --git a/test/config/monitoring.yaml b/test/config/monitoring.yaml
+index ca5244841..cca2f0748 100644
+--- a/test/config/monitoring.yaml
++++ b/test/config/monitoring.yaml
+@@ -44,7 +44,7 @@ spec:
+     spec:
+       containers:
+       - name: zipkin
+-        image: ghcr.io/openzipkin/zipkin:2
++        image: icr.io/upstream-k8s-registry/knative/openzipkin/zipkin:test
+         imagePullPolicy: IfNotPresent
+         ports:
+         - containerPort: 9411
+diff --git a/test/config/sacura-sink-source/300-job.yaml b/test/config/sacura-sink-source/300-job.yaml
+index 2cefa2d68..633b08ee6 100644
+--- a/test/config/sacura-sink-source/300-job.yaml
++++ b/test/config/sacura-sink-source/300-job.yaml
+@@ -45,7 +45,7 @@ spec:
+ 
+       containers:
+         - name: sacura
+-          image: ghcr.io/pierdipi/sacura/sacura-7befbbbc92911c6727467cfbf23af88f
++          image: icr.io/upstream-k8s-registry/knative/bootstrap/sacura:latest
+           args:
+             - "--config"
+             - "/etc/sacura/sacura.yaml"
+diff --git a/test/config/sacura/300-job.yaml b/test/config/sacura/300-job.yaml
+index e72723bcd..cb3113921 100644
+--- a/test/config/sacura/300-job.yaml
++++ b/test/config/sacura/300-job.yaml
+@@ -37,7 +37,7 @@ spec:
+ 
+       containers:
+         - name: sacura
+-          image: ghcr.io/pierdipi/sacura/sacura-7befbbbc92911c6727467cfbf23af88f
++          image: icr.io/upstream-k8s-registry/knative/bootstrap/sacura:latest
+           args:
+             - "--config"
+             - "/etc/sacura/sacura.yaml"
+diff --git a/test/e2e_source/helpers/kafka_helper.go b/test/e2e_source/helpers/kafka_helper.go
+index a565b87c6..fb79d59b0 100644
+--- a/test/e2e_source/helpers/kafka_helper.go
++++ b/test/e2e_source/helpers/kafka_helper.go
+@@ -45,7 +45,7 @@ const (
+ 	strimziUserResource  = "kafkausers"
+ 	interval             = 3 * time.Second
+ 	timeout              = 4 * time.Minute
+-	kcatImage            = "quay.io/openshift-knative/kcat:1.7.1"
++	kcatImage            = "icr.io/upstream-k8s-registry/knative/kafkacat:v1.6.0"
+ )
+ 
+ var (
+diff --git a/third_party/keda/keda.yaml b/third_party/keda/keda.yaml
+index 7faed28d5..f38c3410f 100644
+--- a/third_party/keda/keda.yaml
++++ b/third_party/keda/keda.yaml
+@@ -9407,7 +9407,7 @@ spec:
+           value: ""
+         - name: KEDA_HTTP_DEFAULT_TIMEOUT
+           value: ""
+-        image: ghcr.io/kedacore/keda-admission-webhooks:2.10.1
++        image: icr.io/upstream-k8s-registry/knative/keda-webhook:v2.11.2
+         imagePullPolicy: Always
+         livenessProbe:
+           httpGet:
+@@ -9499,7 +9499,7 @@ spec:
+               fieldPath: metadata.namespace
+         - name: KEDA_HTTP_DEFAULT_TIMEOUT
+           value: ""
+-        image: ghcr.io/kedacore/keda-metrics-apiserver:2.10.1
++        image: icr.io/upstream-k8s-registry/knative/keda-adapter:v2.11.2
+         imagePullPolicy: Always
+         livenessProbe:
+           httpGet:
+@@ -9593,7 +9593,7 @@ spec:
+           value: ""
+         - name: KEDA_HTTP_DEFAULT_TIMEOUT
+           value: ""
+-        image: ghcr.io/kedacore/keda:2.10.1
++        image: icr.io/upstream-k8s-registry/knative/keda-main:v2.11.2
+         imagePullPolicy: Always
+         livenessProbe:
+           httpGet:

--- a/adjust/eventing/release-1.18/adjust.sh
+++ b/adjust/eventing/release-1.18/adjust.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Merge conformance test into the main e2e test
+linesofcode=$(grep -A 100 go_test_e2e test/e2e-conformance-tests.sh  | grep -v success | tr '\n' ' ')
+sed -i "/^success.*/i $linesofcode" test/e2e-tests.sh
+
+sed -i "/^source.*/a export USER=$\(whoami\)" test/e2e-tests.sh
+echo "Increase e2e timeout to 60m"
+sed -i "s/\(go_test_e2e.*\)timeout=1h\(.*\).*/\1timeout=15m\2/g" test/e2e-tests.sh
+sed -i "s/\(go_test_e2e.*\)parallel=20\(.*\).*/\1parallel=1\2/g" test/e2e-tests.sh
+
+echo "Use ppc64le supported zipkin image"
+sed -i "s|image:.*|image: icr.io/upstream-k8s-registry/knative/openzipkin/zipkin:test|g" test/config/monitoring/monitoring.yaml
+echo "Source code patched successfully"

--- a/adjust/kn-plugin-event/release-1.18/adjust.sh
+++ b/adjust/kn-plugin-event/release-1.18/adjust.sh
@@ -1,0 +1,5 @@
+sed -i "/^source.*/a export USER=$\(whoami\)" test/e2e-tests.sh
+sed -i "/^initialize.*/a sleep 60" test/e2e-tests.sh
+sed -i 's/timeout: 5m/timeout: 15m/' .golangci.yaml
+sed -i "/^sleep.*/a kubectl set image deployment/3scale-kourier-gateway kourier-gateway=icr.io/upstream-k8s-registry/knative/maistra/envoy:v2.4 -n kourier-system" test/e2e-tests.sh
+sed -i 's|gcr.io/knative-samples/helloworld-go|quay.io/openshift-knative/client/helloworld:v1.9|g' pkg/k8s/test/addressresolver_cases.go


### PR DESCRIPTION
Changes has been added to adjustment scripts for knative-1.18 version for eventing, eventing-kafka-broker and kn-plugin-event.
The changes has been tested in locally executed prow jobs.