### PR TITLE
Remove monitoring.yaml patch in knative eventing-kafka-broker (main)

### DIFF
--- a/adjust/eventing-kafka-broker/main/ppc64le.patch
+++ b/adjust/eventing-kafka-broker/main/ppc64le.patch
@@ -13,19 +13,6 @@ index 58881521e..380392b62 100644
              - name: STRIMZI_NAMESPACE
                valueFrom:
                  fieldRef:
-diff --git a/test/config/monitoring.yaml b/test/config/monitoring.yaml
-index 9d9ec3dbd..f78302fe0 100644
---- a/test/config/monitoring.yaml
-+++ b/test/config/monitoring.yaml
-@@ -43,7 +43,7 @@ spec:
-     spec:
-       containers:
-       - name: zipkin
--        image: ghcr.io/openzipkin/zipkin:2
-+        image: icr.io/upstream-k8s-registry/knative/openzipkin/zipkin:test
-         imagePullPolicy: IfNotPresent
-         ports:
-         - containerPort: 9411
 diff --git a/test/config/sacura-sink-source/300-job.yaml b/test/config/sacura-sink-source/300-job.yaml
 index 2cefa2d68..633b08ee6 100644
 --- a/test/config/sacura-sink-source/300-job.yaml


### PR DESCRIPTION
In recent [PR#4493](https://github.com/knative-extensions/eventing-kafka-broker/pull/4493) in the `main` branch  of [eventing-kafka-broker](https://github.com/knative-extensions/eventing-kafka-broker) repo, the `monitoring.yaml` config file has been removed. The prow jobs has started failing due to this change.

<img width="700" height="200" alt="image" src="https://github.com/user-attachments/assets/a3b5a96c-aec1-4679-8753-ef3bb810d375" />

This PR will fix the failure caused by the reason mentioned above.