### PR TITLE
Updating new workspace in London region

### DIFF
--- a/cluster-setup.sh
+++ b/cluster-setup.sh
@@ -7,9 +7,9 @@ if [ -z "$1" ]; then
 fi
 
 DEBUG=false
-PVS_REGION='syd'
-PVS_ZONE='syd04'
-PVS_SVC_ID='e04ebc6a-3b99-4b0f-9dcc-f6352033f44b'
+PVS_REGION='eu-gb'
+PVS_ZONE='lon06'
+PVS_SVC_ID='15df767e-d4fe-4089-bae9-227c29e5650c'
 
 if [[ "$1" == "create" ]]
 then


### PR DESCRIPTION
Due to recent requirement, `Knative` jobs have to move out prow jobs from `Sydney` region and shifted to `London` region. This PR will adopt the change in values of PVS `region`, `zone` and `service id `.
The change has been successfully tested with a local `prow` test.

<img width="892" height="340" alt="image" src="https://github.com/user-attachments/assets/cf276076-f1c8-445e-8b6c-721d73a63bbd" />
