### PR TITLE
update kn cleanup schedule

### DIFF
--- a/.github/workflows/knative-clean-pvs-vsi.yaml
+++ b/.github/workflows/knative-clean-pvs-vsi.yaml
@@ -2,7 +2,7 @@ name: Cleanup unused Knative PVS and subnets
 
 on:
   schedule:
-    - cron: "35 17 * * *"  # Runs daily at ~11:05 PM IST)
+    - cron: "35 20 * * *"  # Runs daily at ~02:05 AM IST)
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This PR will update the resource cleanup from ibmcloud. This is required give enough time for serving job to run at 2230 hrs. Thus, the cleanup job will not interfere the last running jobs.